### PR TITLE
Fix settings synchronization and performance metrics

### DIFF
--- a/VideoSzhimaka/Models/VideoFile.swift
+++ b/VideoSzhimaka/Models/VideoFile.swift
@@ -4,12 +4,15 @@ import Foundation
 struct VideoFile: Identifiable, Codable {
     /// Unique identifier for the video file
     let id = UUID()
-    
-    /// URL path to the video file
-    let url: URL
-    
+
+    /// Original URL path to the video file (used for reprocessing/deletion)
+    let originalURL: URL
+
+    /// Current URL used for interactions (may point to the compressed file)
+    var url: URL
+
     /// Display name of the file
-    let name: String
+    var name: String
     
     /// Duration of the video in seconds
     var duration: TimeInterval
@@ -28,15 +31,46 @@ struct VideoFile: Identifiable, Codable {
     
     /// Custom coding keys to handle UUID serialization
     private enum CodingKeys: String, CodingKey {
-        case url, name, duration, originalSize, compressedSize, compressionProgress, status
+        case url, name, duration, originalSize, compressedSize, compressionProgress, status, originalURL
     }
     
     /// Initialize a new VideoFile
     init(url: URL, name: String, duration: TimeInterval, originalSize: Int64) {
+        self.originalURL = url
         self.url = url
         self.name = name
         self.duration = duration
         self.originalSize = originalSize
+    }
+}
+
+// MARK: - Codable
+
+extension VideoFile {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedURL = try container.decode(URL.self, forKey: .url)
+
+        self.url = decodedURL
+        self.originalURL = try container.decodeIfPresent(URL.self, forKey: .originalURL) ?? decodedURL
+        self.name = try container.decode(String.self, forKey: .name)
+        self.duration = try container.decode(TimeInterval.self, forKey: .duration)
+        self.originalSize = try container.decode(Int64.self, forKey: .originalSize)
+        self.compressedSize = try container.decodeIfPresent(Int64.self, forKey: .compressedSize)
+        self.compressionProgress = try container.decodeIfPresent(Double.self, forKey: .compressionProgress) ?? 0.0
+        self.status = try container.decodeIfPresent(CompressionStatus.self, forKey: .status) ?? .pending
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(url, forKey: .url)
+        try container.encode(originalURL, forKey: .originalURL)
+        try container.encode(name, forKey: .name)
+        try container.encode(duration, forKey: .duration)
+        try container.encode(originalSize, forKey: .originalSize)
+        try container.encodeIfPresent(compressedSize, forKey: .compressedSize)
+        try container.encode(compressionProgress, forKey: .compressionProgress)
+        try container.encode(status, forKey: .status)
     }
 }
 

--- a/VideoSzhimaka/Services/PerformanceMonitorService.swift
+++ b/VideoSzhimaka/Services/PerformanceMonitorService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 import os.log
 
 /// Service for monitoring performance and resource usage during video compression
@@ -120,23 +121,29 @@ class PerformanceMonitorService: ObservableObject {
     }
     
     private func getCPUUsage() -> Double {
-        var info = mach_task_basic_info()
-        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size)/4
-        
-        let kerr: kern_return_t = withUnsafeMutablePointer(to: &info) {
-            $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
-                task_info(mach_task_self_,
-                         task_flavor_t(MACH_TASK_BASIC_INFO),
-                         $0,
-                         &count)
+        var count = mach_msg_type_number_t(MemoryLayout<host_cpu_load_info_data_t>.stride / MemoryLayout<integer_t>.stride)
+        var cpuLoadInfo = host_cpu_load_info_data_t()
+
+        let result = withUnsafeMutablePointer(to: &cpuLoadInfo) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO, $0, &count)
             }
         }
-        
-        if kerr == KERN_SUCCESS {
-            return Double(info.resident_size) / Double(ProcessInfo.processInfo.physicalMemory) * 100.0
+
+        guard result == KERN_SUCCESS else {
+            return 0.0
         }
-        
-        return 0.0
+
+        let user = Double(cpuLoadInfo.cpu_ticks.0)
+        let system = Double(cpuLoadInfo.cpu_ticks.1)
+        let idle = Double(cpuLoadInfo.cpu_ticks.2)
+        let nice = Double(cpuLoadInfo.cpu_ticks.3)
+
+        let totalTicks = user + system + idle + nice
+        guard totalTicks > 0 else { return 0.0 }
+
+        let activeTicks = user + system + nice
+        return (activeTicks / totalTicks) * 100.0
     }
     
     private func getMemoryUsage() -> Double {

--- a/VideoSzhimaka/Utilities/PerformanceOptimizer.swift
+++ b/VideoSzhimaka/Utilities/PerformanceOptimizer.swift
@@ -38,7 +38,7 @@ class PerformanceOptimizer {
     
     /// Check if system is under memory pressure
     func isUnderMemoryPressure() -> Bool {
-        let memoryInfo = mach_task_basic_info()
+        var memoryInfo = mach_task_basic_info()
         var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size)/4
         
         let result = withUnsafeMutablePointer(to: &memoryInfo) {

--- a/VideoSzhimaka/ViewModels/MainViewModel.swift
+++ b/VideoSzhimaka/ViewModels/MainViewModel.swift
@@ -79,7 +79,7 @@ class MainViewModel: ObservableObject {
     /// - Parameter url: URL of the video file to add
     private func addSingleFile(_ url: URL) {
         // Check if file already exists in the list
-        if videoFiles.contains(where: { $0.url == url }) {
+        if videoFiles.contains(where: { $0.url == url || $0.originalURL == url }) {
             loggingService.warning("Файл уже добавлен: \(url.lastPathComponent)", category: "FileManagement")
             return
         }
@@ -335,7 +335,7 @@ class MainViewModel: ObservableObject {
             }
             
             // Generate output URL
-            let outputURL = fileManagerService.generateOutputURL(for: file.url)
+            let outputURL = fileManagerService.generateOutputURL(for: file.originalURL)
             
             // Adjust settings based on performance recommendations
             var adjustedSettings = settingsService.settings
@@ -349,7 +349,7 @@ class MainViewModel: ObservableObject {
             
             // Compress the video
             try await ffmpegService.compressVideo(
-                input: file.url,
+                input: file.originalURL,
                 output: outputURL,
                 settings: adjustedSettings
             ) { [weak self] progress in
@@ -373,22 +373,28 @@ class MainViewModel: ObservableObject {
             // Get compressed file size
             let compressedSize = try fileManagerService.getFileSize(url: outputURL)
             
+            let isCompressedLarger = compressedSize > file.originalSize
+
             // Safely update file status using fileId instead of index
             if let currentIndex = videoFiles.firstIndex(where: { $0.id == fileId }) {
                 videoFiles[currentIndex].status = .completed
                 videoFiles[currentIndex].compressedSize = compressedSize
                 videoFiles[currentIndex].compressionProgress = 1.0
+
+                if !isCompressedLarger {
+                    videoFiles[currentIndex].url = outputURL
+                    videoFiles[currentIndex].name = outputURL.lastPathComponent
+                }
             }
-            
+
             let compressionRatio = (1.0 - Double(compressedSize) / Double(file.originalSize)) * 100.0
-            
+
             // Log performance metrics
             let finalMetrics = performanceMonitor.getCurrentMetrics()
             loggingService.info("Сжатие завершено: \(file.name) (\(file.originalSize.formattedFileSize) → \(compressedSize.formattedFileSize), экономия: \(String(format: "%.1f", compressionRatio))%)", category: "Compression")
             loggingService.info("Производительность: CPU \(String(format: "%.1f", finalMetrics.cpuUsage))%, Память \(String(format: "%.1f", finalMetrics.memoryUsage))MB, Температура: \(finalMetrics.thermalState.description)", category: "Performance")
-            
+
             // If compressed file is larger than original, delete the compressed file immediately
-            let isCompressedLarger = compressedSize > file.originalSize
             if isCompressedLarger {
                 do {
                     try fileManagerService.deleteFile(at: outputURL)
@@ -401,7 +407,7 @@ class MainViewModel: ObservableObject {
             // Delete original file if requested, but only when compressed is not larger
             if settingsService.settings.deleteOriginals {
                 if !isCompressedLarger {
-                    try fileManagerService.deleteFile(at: file.url)
+                    try fileManagerService.deleteFile(at: file.originalURL)
                     loggingService.info("Оригинальный файл удален: \(file.name)", category: "FileManagement")
                 } else {
                     loggingService.info("Оригинал НЕ удален, так как сжатый файл оказался больше", category: "FileManagement")
@@ -524,6 +530,7 @@ class MainViewModel: ObservableObject {
     func handleDrop(_ providers: [NSItemProvider]) -> Bool {
         let group = DispatchGroup()
         var urls: [URL] = []
+        let urlAccessQueue = DispatchQueue(label: "com.videoszhimaka.dropurls")
         
         for provider in providers {
             group.enter()
@@ -533,14 +540,18 @@ class MainViewModel: ObservableObject {
                 
                 if let data = item as? Data,
                    let url = URL(dataRepresentation: data, relativeTo: nil) {
-                    urls.append(url)
+                    urlAccessQueue.sync {
+                        urls.append(url)
+                    }
                 }
             }
         }
-        
+
         group.notify(queue: .main) { [weak self] in
+            let collectedURLs = urlAccessQueue.sync { urls }
+
             // Filter for video files
-            let videoURLs = urls.filter { url in
+            let videoURLs = collectedURLs.filter { url in
                 let pathExtension = url.pathExtension.lowercased()
                 return ["mp4", "mov", "mkv", "avi", "webm", "flv", "wmv", "m4v"].contains(pathExtension)
             }
@@ -713,13 +724,13 @@ class MainViewModel: ObservableObject {
 
 extension MainViewModel {
     /// Convenience initializer for dependency injection in production
-    convenience init() {
+    convenience init(settingsService: any SettingsServiceProtocol) {
         do {
             let ffmpegService = try FFmpegService()
             self.init(
                 ffmpegService: ffmpegService,
                 fileManagerService: FileManagerService(),
-                settingsService: SettingsService(),
+                settingsService: settingsService,
                 loggingService: LoggingService(),
                 performanceMonitor: PerformanceMonitorService.shared
             )
@@ -729,16 +740,20 @@ extension MainViewModel {
             self.init(
                 ffmpegService: fallbackFFmpegService,
                 fileManagerService: FileManagerService(),
-                settingsService: SettingsService(),
+                settingsService: settingsService,
                 loggingService: LoggingService(),
                 performanceMonitor: PerformanceMonitorService.shared
             )
-            
+
             // Set the error state after initialization
             Task { @MainActor in
                 self.currentError = .ffmpegNotFound
             }
         }
+    }
+
+    convenience init() {
+        self.init(settingsService: SettingsService())
     }
 }
 

--- a/VideoSzhimaka/Views/ContentView.swift
+++ b/VideoSzhimaka/Views/ContentView.swift
@@ -2,19 +2,21 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct ContentView: View {
+    @EnvironmentObject private var settingsService: SettingsService
+
     var body: some View {
-        MainView()
+        MainView(settingsService: settingsService)
     }
 }
 
 struct MainView: View {
-    @EnvironmentObject private var settingsService: SettingsService
+    @ObservedObject private var settingsService: SettingsService
     @StateObject private var viewModel: MainViewModel
     @AppStorage("appTheme") private var appTheme: String = "dark" // "light" or "dark"
     
-    init() {
-        // Create viewModel with default services - will be updated in onAppear
-        self._viewModel = StateObject(wrappedValue: MainViewModel())
+    init(settingsService: SettingsService) {
+        self._settingsService = ObservedObject(initialValue: settingsService)
+        self._viewModel = StateObject(wrappedValue: MainViewModel(settingsService: settingsService))
     }
     
     var body: some View {
@@ -53,7 +55,7 @@ struct MainView: View {
             }
         }
         .sheet(isPresented: $viewModel.showSettings) {
-            SettingsView()
+            SettingsView(settingsService: settingsService)
                 .environmentObject(settingsService)
         }
         .sheet(isPresented: $viewModel.showLogs) {
@@ -216,4 +218,5 @@ struct FooterView: View {
 
 #Preview {
     ContentView()
+        .environmentObject(SettingsService())
 }

--- a/VideoSzhimaka/Views/SettingsView.swift
+++ b/VideoSzhimaka/Views/SettingsView.swift
@@ -2,9 +2,18 @@ import SwiftUI
 
 /// Settings panel view for configuring compression parameters
 struct SettingsView: View {
-    @StateObject private var viewModel = SettingsViewModel()
+    @StateObject private var viewModel: SettingsViewModel
     @Environment(\.dismiss) private var dismiss
-    
+    @State private var showUnsavedChangesConfirmation = false
+
+    init(settingsService: SettingsService) {
+        self._viewModel = StateObject(wrappedValue: SettingsViewModel(settingsService: settingsService))
+    }
+
+    init(viewModel: SettingsViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Header
@@ -19,12 +28,7 @@ struct SettingsView: View {
                     dismiss()
                 },
                 onClose: {
-                    if viewModel.hasUnsavedChanges {
-                        // Show unsaved changes dialog
-                        // For now, just discard changes
-                        viewModel.discardChanges()
-                    }
-                    dismiss()
+                    handleCloseRequest()
                 }
             )
             
@@ -77,6 +81,32 @@ struct SettingsView: View {
             Button("Отмена", role: .cancel) {}
         } message: {
             Text("Все настройки будут сброшены к значениям по умолчанию. Это действие нельзя отменить.")
+        }
+        .interactiveDismissDisabled(viewModel.hasUnsavedChanges)
+        .confirmationDialog(
+            "Сохранить изменения?",
+            isPresented: $showUnsavedChangesConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Сохранить изменения") {
+                viewModel.saveSettings()
+                dismiss()
+            }
+            Button("Не сохранять", role: .destructive) {
+                viewModel.discardChanges()
+                dismiss()
+            }
+            Button("Отмена", role: .cancel) {}
+        } message: {
+            Text("Есть несохранённые изменения. Сохранить их перед закрытием?")
+        }
+    }
+
+    private func handleCloseRequest() {
+        if viewModel.hasUnsavedChanges {
+            showUnsavedChangesConfirmation = true
+        } else {
+            dismiss()
         }
     }
 }
@@ -337,5 +367,5 @@ struct ResetSettingsView: View {
 // MARK: - Previews
 
 #Preview {
-    SettingsView()
+    SettingsView(viewModel: .preview)
 }


### PR DESCRIPTION
## Summary
- share the root SettingsService with MainViewModel and SettingsView so UI and logic stay in sync and prompt before discarding unsaved changes
- track both original and current video URLs to keep Finder actions valid, update compression flow accordingly, and harden drag & drop handling
- compute CPU usage from host statistics and fix the Mach memory pressure call so the project builds again

## Testing
- `xcodebuild -version` *(fails: command not found in the Linux container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9dac508b883288a6ce42946c2c08f